### PR TITLE
Remove build-engine: buildx

### DIFF
--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -15,4 +15,3 @@ jobs:
       name: dev-toolbox
       dockerfile: Dockerfile
       tags: "${{ github.sha }},PR-${{ github.event.number }}"
-      build-engine: buildx

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,4 +15,3 @@ jobs:
       name: dev-toolbox
       dockerfile: Dockerfile
       tags: "${{ github.sha }},${{ github.ref_name}}"
-      build-engine: buildx

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,4 +37,3 @@ jobs:
       name: dev-toolbox
       dockerfile: Dockerfile
       tags: "${{ github.sha }},${{ github.event.inputs.name }}"
-      build-engine: buildx


### PR DESCRIPTION
This PR removes the deprecated `build-engine: buildx` entry from workflows.